### PR TITLE
fix: change double to float

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -417,7 +417,7 @@ function sqlTypeCast(type) {
     case '_string':
       return 'VARCHAR(max)';
     case '_number':
-      return 'DOUBLE';
+      return 'FLOAT';
     case '_boolean':
       return 'TINYINT';
     case '_json':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-mssql",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "SQL Server Adapter for Sails / Waterline",
   "main": "lib/adapter.js",
   "scripts": {


### PR DESCRIPTION
SQL Server "double" is called "float"
Resolve Issue #6 

thanks eckolosst for the tip!