### PR TITLE
parsing varchar/nvarchar(length) in columnType

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -404,6 +404,17 @@ function parseSort(collectionName, sort) {
 function sqlTypeCast(type) {
   type = type && type.toLowerCase();
 
+  // if nvarchar or varchar, check if length specified in column type
+  if (
+    (type.substring(0, 8) === "nvarchar" ||
+      type.substring(0, 7) === "varchar") &&
+    type.includes("(") && type.includes(")")
+  ) {
+    var length = type.substring(type.indexOf("(") + 1, type.indexOf(")"));
+    // remove precision from input type
+    type = type.substring(0, type.indexOf("("))
+  }
+
   switch (type) {
     // https://github.com/balderdashy/waterline/blob/master/ARCHITECTURE.md#reserved-column-types
     case '_numberkey':
@@ -442,7 +453,7 @@ function sqlTypeCast(type) {
     case "array":
     case "text":
     case "varchar":
-      return "VARCHAR(max)";
+      return `VARCHAR(${length ? length : "max"})`;
 
     case "int":
     case "integer":


### PR DESCRIPTION
I added a few lines of code to support passing a length to varchar column types. In the sails/waterline model, you specific columnLength(x), where x is the desired column length (for example, varchar(200)). This will result in the SQL Server column being created with the desired length, rather than defaulting to varchar(max) or varchar(1) when an invalid column type is passed.