### PR TITLE
Support for sqlazure sql edition

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -704,7 +704,6 @@ var adapter = {
     try {
 
       // if sql server old version
-
       if (!registeredDatastores[datastoreName].manager.version) {
         const connection = (await registeredDatastores[datastoreName].driver.getConnection({
           manager: registeredDatastores[datastoreName].manager,
@@ -715,7 +714,19 @@ var adapter = {
         });
         registeredDatastores[datastoreName].manager.version = Number(Object.values(report.result.recordsets[0][0])[0].split('.')[0])
       }
-      if (registeredDatastores[datastoreName].manager.version < 13) {
+      // get sql server edition
+      if (!registeredDatastores[datastoreName].manager.edition) {
+        const connection = (await registeredDatastores[datastoreName].driver.getConnection({
+          manager: registeredDatastores[datastoreName].manager,
+        })).connection;
+        const report = await registeredDatastores[datastoreName].driver.sendNativeQuery({
+          connection: connection,
+          nativeQuery: 'select serverproperty(\'Edition\')'
+        });
+        registeredDatastores[datastoreName].manager.edition = String(Object.values(report.result.recordsets[0][0])[0])
+      }
+      // if sql 2014 or lower, and not SQL Azure, FOR JSON not supported, so run old join code
+      if (registeredDatastores[datastoreName].manager.version < 13 && registeredDatastores[datastoreName].manager.edition !== "SQL Azure") {
         return adapter.oldJoin(datastoreName, query, cb);
       }
 

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -404,6 +404,17 @@ function parseSort(collectionName, sort) {
 function sqlTypeCast(type) {
   type = type && type.toLowerCase();
 
+  // if nvarchar or varchar, check if length specified in column type
+  if (
+    (type.substring(0, 8) === "nvarchar" ||
+      type.substring(0, 7) === "varchar") &&
+    type.includes("(") && type.includes(")")
+  ) {
+    var length = type.substring(type.indexOf("(") + 1, type.indexOf(")"));
+    // remove precision from input type
+    type = type.substring(0, type.indexOf("("))
+  }
+
   switch (type) {
     // https://github.com/balderdashy/waterline/blob/master/ARCHITECTURE.md#reserved-column-types
     case '_numberkey':
@@ -442,7 +453,7 @@ function sqlTypeCast(type) {
     case "array":
     case "text":
     case "varchar":
-      return "VARCHAR(max)";
+      return `VARCHAR(${length ? length : "max"})`;
 
     case "int":
     case "integer":


### PR DESCRIPTION
SQL Azure productversion is 12, but SQL Azure does support FOR JSON. Added some code to get the SQL Edition, and if SQL Azure, then allow the code to use the FOR JSON rather than the adapter.oldJoin.
All unit tests passed.