### PR TITLE
Allow instance name in connection string

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -248,7 +248,7 @@ var adapter = {
       protocol  user     password     host          port     database
     */
 
-    var urlMatches = datastoreConfig.url.match(/^mssql:\/\/([^:]+):([^@]+)@([^/:]+)(?::([^:]+))?\/([^/]+)$/);
+    var urlMatches = datastoreConfig.url.match(/^mssql:\/\/([^:]+):([^@]+)@([^/:]+)(?:(?::(\d+))?\/([^/]+)|\/([^/]+)\/([^/]+))$/);
     if (!urlMatches) {
       return done(new Error('Invalid configuration for datastore `' + datastoreName + '`:  `url` definition does not follow the pattern'));
     }


### PR DESCRIPTION
Also only allow numbers for port in connection string.

This combined with intel/machinepack-mssql#6 closes #13 and intel/machinepack-mssql#5