### PR TITLE
Old schema support for queries added

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -279,7 +279,7 @@ var adapter = {
         definition: definition,
         attributes: definition,
         primaryKey: val.primaryKey,
-        meta: {schemaName = datastoreConfig.schemaName}
+        meta: {schemaName: datastoreConfig.schemaName}
       };
     });
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -278,7 +278,8 @@ var adapter = {
         tableName: tableName,
         definition: definition,
         attributes: definition,
-        primaryKey: val.primaryKey
+        primaryKey: val.primaryKey,
+        meta: {schemaName = datastoreConfig.schemaName}
       };
     });
 
@@ -1266,9 +1267,8 @@ function marshalConfig(_config) {
 }
 
 function getSchemaName(datastoreName, tableName) {
-  // var schemaObject = registeredDatastores[datastoreName].dbSchema[tableName];
-  // return schemaObject.meta && schemaObject.meta.schemaName ? schemaObject.meta.schemaName : 'dbo';
-  return 'dbo';
+  var schemaObject = registeredDatastores[datastoreName].dbSchema[tableName];
+  return schemaObject.meta && schemaObject.meta.schemaName ? schemaObject.meta.schemaName : 'dbo';
 }
 
 


### PR DESCRIPTION
Add a schemaName to the datastore adapter and it will select from [schemaName].[table] instead of [dbo].[table], then set that datastore to your models and you'll be ready to rock!